### PR TITLE
Fix org-block detection for composite faces

### DIFF
--- a/valign.el
+++ b/valign.el
@@ -531,7 +531,7 @@ TYPE must be 'org.  Start at point, stop at LIMIT."
     (let ((face (plist-get (text-properties-at (point)) 'face)))
       ;; Don’t align tables in org blocks.
       (not (and (consp face)
-                (or (equal face '(org-block))
+                (or (memq 'org-block face)
                     (equal (plist-get face :inherit)
                            '(org-block))))))))
 


### PR DESCRIPTION
This fixes a false-positive alignment issue in Org buffers when valign-mode is enabled.

Inside an Org src block with native fontification, faces can be composite, for example:
(diff-indicator-added org-block)

The current org-block skip logic is too narrow and can miss this case,
which allows valign to treat diff lines like `+- ...` as table.el-style
ASCII borders.

This change treats composite faces containing `org-block` as being inside
an Org block as well, so alignment is skipped there.